### PR TITLE
Update API

### DIFF
--- a/post_task.sh
+++ b/post_task.sh
@@ -1,4 +1,4 @@
-curl "https://beta.todoist.com/API/v8/tasks" \
+curl "https://api.todoist.com/rest/v1/tasks" \
     -X POST \
 --data "{\"project_id\": $project_id, \"content\": \"$content\", \"due_string\": \"$due_string\", \"due_lang\": \"$due_lang\", \"priority\": $priority, \"label_ids\": [$label1]}" \
     -H "Content-Type: application/json" \

--- a/projects_todo.sh
+++ b/projects_todo.sh
@@ -1,2 +1,2 @@
-curl "https://beta.todoist.com/API/v8/projects" \
+curl "https://api.todoist.com/rest/v1/projects" \
     -H "Authorization: Bearer $bearer"

--- a/tasks_todo.sh
+++ b/tasks_todo.sh
@@ -1,2 +1,2 @@
-curl "https://beta.todoist.com/API/v8/labels" \
+curl "https://api.todoist.com/rest/v1/labels" \
     -H "Authorization: Bearer $bearer"


### PR DESCRIPTION
It seems beta API v8 [was removed on August 30th 2019](https://github.com/darkSasori/todoist/issues/6) so this PR just involves changing the API endpoint to the new one: `https://api.todoist.com/rest/v1/tasks`.